### PR TITLE
fix pixel size for medium resolution displays

### DIFF
--- a/osd.v
+++ b/osd.v
@@ -35,6 +35,8 @@ parameter OSD_AUTO_CE  = 1'b1;
 localparam OSD_WIDTH   = 10'd256;
 localparam OSD_HEIGHT  = 10'd128;
 
+localparam OSD_WIDTH_PADDED = OSD_WIDTH + (OSD_WIDTH >> 1);  // 25% padding left and right
+
 // *********************************************************************************
 // spi client
 // *********************************************************************************
@@ -111,9 +113,11 @@ always @(posedge clk_sys) begin
 	auto_ce_pix <= !pixcnt;
 
 	if(hs && ~HSync) begin
-		cnt    <= 0;
-		if (cnt <= 512) pixsz = 0;
-		else pixsz  <= (cnt >> 9) - 1;
+		cnt <= 0;	
+		     if(cnt <= OSD_WIDTH_PADDED * 2) pixsz = 0;  
+		else if(cnt <= OSD_WIDTH_PADDED * 3) pixsz = 1;  
+		else if(cnt <= OSD_WIDTH_PADDED * 4) pixsz = 2;  
+		else pixsz = 3;
 		pixcnt <= 0;
 		auto_ce_pix <= 1;
 	end


### PR DESCRIPTION
As I'm working with a core that features a 640x192 PAL resolution (948 clock pixels), I noticed the OSD menu looks too narrow of what it could be (horizontally). 

This pull request increases `pixelsz` proportionally with the horizontal resolution, always leaving 25 % of padding space around the left and right side of the menu. 

Compared to the actual version, it increases `pixelsz` by 1 in the range 768-1023 pixels. 

