### PR TITLE
[OSD] extend pixsz to include higher clock speeds

### DIFF
--- a/osd.v
+++ b/osd.v
@@ -102,8 +102,8 @@ wire doublescan = (dsp_height>350);
 reg auto_ce_pix;
 always @(posedge clk_sys) begin
 	reg [15:0] cnt = 0;
-	reg  [1:0] pixsz;
-	reg  [1:0] pixcnt;
+	reg  [2:0] pixsz;
+	reg  [2:0] pixcnt;
 	reg        hs;
 
 	cnt <= cnt + 1'd1;
@@ -118,7 +118,9 @@ always @(posedge clk_sys) begin
 		if(cnt <= OSD_WIDTH_PADDED * 2) pixsz <= 0;
 		else if(cnt <= OSD_WIDTH_PADDED * 3) pixsz <= 1;
 		else if(cnt <= OSD_WIDTH_PADDED * 4) pixsz <= 2;
-		else pixsz <= 3;
+		else if(cnt <= OSD_WIDTH_PADDED * 5) pixsz <= 3;
+		else if(cnt <= OSD_WIDTH_PADDED * 6) pixsz <= 4;
+		else pixsz <= 5;
 
 		pixcnt <= 0;
 		auto_ce_pix <= 1;


### PR DESCRIPTION
(previously discussed [here](https://github.com/mist-devel/mist-firmware/issues/56))

At high video clock speeds, the OSD menu width is smaller than the ideal size, due to `pixsz` reaching the limit of `3`.

This PR extends the calculation  of `pixsz` adding two more cases (which I think they should be enough).

In my project I have a video of 10.7 Mhz running at 4x speed (42.8 MHz). While this speed may seem exaggerate, it's justified by the fact that video and CPU aren't synchronous and I have to resolve cross-clock domain with a bit of latency, so the higher the speed the better.

