### PR TITLE
changes required to be compiled on Vivado (define .v files as SystemVerilog also)

### DIFF
--- a/data_io.v
+++ b/data_io.v
@@ -56,7 +56,7 @@ module data_io
 	input             hdd_dat_req,
 	output            hdd_cdda_wr,
 	output            hdd_status_wr,
-	output      [2:0] hdd_addr = 0,
+	output      [2:0] hdd_addr,
 	output            hdd_wr,
 
 	output     [15:0] hdd_data_out,

--- a/user_io.v
+++ b/user_io.v
@@ -254,11 +254,11 @@ always@(negedge spi_sck or posedge SPI_SS_IO) begin : spi_byteout
 	end
 end
 
-generate if (ARCHIE) begin
 reg  [7:0] kbd_out_status;
 reg  [7:0] kbd_out_data_r;
 reg        kbd_out_data_available = 0;
 
+generate if (ARCHIE) begin
 always@(negedge spi_sck or posedge SPI_SS_IO) begin : archie_kbd_out
 	if(SPI_SS_IO == 1) begin
 		kbd_out_data_r <= 0;


### PR DESCRIPTION
Changes needed to be able to do Synthesis step in Vivado.
.v files Type property need to be defined as SystemVerilog to avoid further errors.

Not sure if it has processed all files or only the ones used in PCXT core.