### PR TITLE
Expose osd status in mist_video

### DIFF
--- a/mist_video.v
+++ b/mist_video.v
@@ -40,6 +40,9 @@ module mist_video
 	input        HSync,
 	input        VSync,
 
+	// OSD on/off indicator
+	output       osd_enable,
+    
 	// MiST video output signals
 	output reg [OUT_COLOR_DEPTH-1:0] VGA_R,
 	output reg [OUT_COLOR_DEPTH-1:0] VGA_G,
@@ -118,7 +121,8 @@ osd #(OSD_X_OFFSET, OSD_Y_OFFSET, OSD_COLOR, OSD_AUTO_CE, USE_BLANKS, OUT_COLOR_
 	.VSync   ( SD_VS_O ),
 	.R_out   ( osd_r_o ),
 	.G_out   ( osd_g_o ),
-	.B_out   ( osd_b_o )
+	.B_out   ( osd_b_o ),
+	.osd_enable(osd_enable)
 );
 
 wire [OUT_COLOR_DEPTH-1:0] cofi_r, cofi_g, cofi_b;

--- a/osd.v
+++ b/osd.v
@@ -26,7 +26,9 @@ module osd (
 	// VGA signals going to video connector
 	output [OUT_COLOR_DEPTH-1:0] R_out,
 	output [OUT_COLOR_DEPTH-1:0] G_out,
-	output [OUT_COLOR_DEPTH-1:0] B_out
+	output [OUT_COLOR_DEPTH-1:0] B_out,
+    
+	output reg osd_enable
 );
 
 parameter OSD_X_OFFSET = 11'd0;
@@ -49,7 +51,6 @@ localparam OSD_WIDTH_PADDED = OSD_WIDTH + (OSD_WIDTH >> 1);  // 25% padding left
 
 // this core supports only the display related OSD commands
 // of the minimig
-reg        osd_enable;
 (* ramstyle = "no_rw_check" *) reg  [7:0] osd_buffer[256*OSD_LINES-1:0];  // the OSD buffer itself
 
 // the OSD has its own SPI interface to the io controller


### PR DESCRIPTION
This small change allows the core to be aware of whether the OSD is visible or not, which would be exposed through mist_video.

This can be used to pause the emulation while the OSD is visible or any other bizarre/imaginative needs.

Don't know if there is any other way to do this with the current implementation, but in case there isn't, please consider this CR.
