### PR TITLE
Fix order in serial stream (first status, then data)

### DIFF
--- a/user_io.v
+++ b/user_io.v
@@ -346,7 +346,7 @@ always@(posedge spi_sck or posedge SPI_SS_IO) begin : spi_transmitter
 
 			8'h1b:
 				// send alternating flag byte and data
-				if(byte_cnt[0]) spi_byte_out <= serial_out_status;
+				if(~byte_cnt[0]) spi_byte_out <= serial_out_status;
 				else spi_byte_out <= serial_out_byte;
 
 			// keyboard LED status


### PR DESCRIPTION
user_io command 1b sends the bytes reversed to the expectation of the firmware. Status should be sent first, and afterwards the data.
